### PR TITLE
Extend available docker tags

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,20 @@
-docker build -t fiware/ckan-extended:2.8 .
-docker build -t fiware/ckan-extended:2.7 . -f Dockerfile-2.7
+version="7.7"
+full_version="${version}.0"
 
-docker tag fiware/ckan-extended:2.8 fiware/ckan-extended:latest
+docker build --squash -t fiware/ckan-extended:2.8-${full_version} .
+docker build --squash -t fiware/ckan-extended:2.7-${full_version} . -f Dockerfile-2.7
+
+docker tag fiware/ckan-extended:2.8-${full_version} fiware/ckan-extended:2.8-${version}
+docker tag fiware/ckan-extended:2.7-${full_version} fiware/ckan-extended:2.7-${version}
+docker tag fiware/ckan-extended:2.8-${full_version} fiware/ckan-extended:${full_version}
+docker tag fiware/ckan-extended:2.8-${full_version} fiware/ckan-extended:${version}
+docker tag fiware/ckan-extended:2.8-${version} fiware/ckan-extended:latest
+
+
+docker push fiware/ckan-extended:2.8-${full_version}
+docker push fiware/ckan-extended:2.7-${full_version}
+docker push fiware/ckan-extended:2.8-${version}
+docker push fiware/ckan-extended:2.7-${version}
+docker push fiware/ckan-extended:${full_version}
+docker push fiware/ckan-extended:${version}
+docker push fiware/ckan-extended:latest


### PR DESCRIPTION
This PR extends the build docker images when using the `build.sh` script. The idea is to build the following tags for v7.7.0:

- `:2.8-7.7.0`
- `:2.7-7.7.0`
- `:2.8-7.7` equivalent to `:2.8-7.7.${minor}` using the latest minor version released
- `:2.7-7.7` equivalent to `:2.7-7.7.${minor}` using the latest minor version released
- `:7.7.0` equivalent to `:2.8-7.7.0`
- `:7.7` equivalent to `:2.8-7.7.${minor}` using the latest minor version released
- and `:latest` with the latest stable version